### PR TITLE
Update couchdb_peruser package for CouchDB 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: erlang
 
 otp_release:
+  - 19.0
   - 18.0
   - 17.5
   - R16B03-1
-  - R14B04
 
 before_install:
   - sudo apt-get update -qq

--- a/src/couch_peruser.erl
+++ b/src/couch_peruser.erl
@@ -14,6 +14,7 @@
 -behaviour(gen_server).
 
 -include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/include/mem3.hrl").
 
 -define(USERDB_PREFIX, "userdb-").
 
@@ -24,6 +25,7 @@
 -export([init_changes_handler/1, changes_handler/3]).
 
 -record(state, {parent, db_name, delete_dbs, changes_pid, changes_ref}).
+-record(clusterState, {parent, db_name, delete_dbs, states}).
 
 -define(RELISTEN_DELAY, 5000).
 
@@ -34,17 +36,28 @@ start_link() ->
 init() ->
     case config:get_boolean("couch_peruser", "enable", false) of
     false ->
-        #state{};
+        #clusterState{};
     true ->
         DbName = ?l2b(config:get(
                          "couch_httpd_auth", "authentication_db", "_users")),
         DeleteDbs = config:get_boolean("couch_peruser", "delete_dbs", false),
-        State = #state{parent = self(),
-                       db_name = DbName,
+
+        ClusterState = #clusterState{
+            parent = self(),
+            db_name = DbName,
+            delete_dbs = DeleteDbs
+        },
+
+        States = lists:map(fun (A) ->
+            S = #state{parent = ClusterState#clusterState.parent,
+                       db_name = A#shard.name,
                        delete_dbs = DeleteDbs},
-        {Pid, Ref} = spawn_opt(
-            ?MODULE, init_changes_handler, [State], [link, monitor]),
-        State#state{changes_pid=Pid, changes_ref=Ref}
+            {Pid, Ref} = spawn_opt(
+                ?MODULE, init_changes_handler, [S], [link, monitor]),
+            S#state{changes_pid=Pid, changes_ref=Ref}
+        end, mem3:local_shards(DbName)),
+
+        ClusterState#clusterState{states = States}
     end.
 
 init_changes_handler(#state{db_name=DbName} = State) ->
@@ -172,12 +185,15 @@ init([]) ->
 handle_call(_Msg, _From, State) ->
     {reply, error, State}.
 
-handle_cast(update_config, State) when State#state.changes_pid =/= undefined ->
-    % we don't want to have multiple changes handler at the same time
-    demonitor(State#state.changes_ref, [flush]),
-    exit(State#state.changes_pid, kill),
+
+handle_cast(update_config, ClusterState) when ClusterState#clusterState.states =/= undefined ->
+    lists:foreach(fun (State) ->
+        demonitor(State#state.changes_ref, [flush]),
+        exit(State#state.changes_pid, kill)
+    end, ClusterState#clusterState.states),
+
     {noreply, init()};
-handle_cast(update_config, _State) ->
+handle_cast(update_config, _) ->
     {noreply, init()};
 handle_cast(stop, State) ->
     {stop, normal, State};

--- a/test/couch_peruser_test.erl
+++ b/test/couch_peruser_test.erl
@@ -30,14 +30,16 @@ teardown_all(TestCtx) ->
 setup() ->
     TestAuthDb = ?tempdb(),
     do_request(put, get_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
+    do_request(put, get_cluster_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
     set_config("couch_httpd_auth", "authentication_db", ?b2l(TestAuthDb)),
     set_config("couch_peruser", "enable", "true"),
     TestAuthDb.
 
 teardown(TestAuthDb) ->
-    set_config("couch_httpd_auth", "authentication_db", "_users"),
     set_config("couch_peruser", "enable", "false"),
     set_config("couch_peruser", "delete_dbs", "false"),
+    set_config("couch_httpd_auth", "authentication_db", "_users"),
+    do_request(delete, get_cluster_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
     do_request(delete, get_base_url() ++ "/" ++ ?b2l(TestAuthDb)),
     lists:foreach(fun (DbName) ->
         case DbName of
@@ -61,6 +63,11 @@ do_request(Method, Url, Body) ->
         {"Content-Type", "application/json"}],
     {ok, _, _, _} = test_request:request(Method, Url, Headers, Body).
 
+do_anon_request(Method, Url, Body) ->
+    Headers = [
+        {"Content-Type", "application/json"}],
+    {ok, _, _, _} = test_request:request(Method, Url, Headers, Body).
+
 create_db(DbName) ->
     {ok, _, _, _} = do_request(put, get_cluster_base_url() ++ "/" ++ ?b2l(DbName)).
 
@@ -71,13 +78,22 @@ create_user(AuthDb, Name) ->
     Body = "{\"name\":\"" ++ Name ++
         "\",\"type\":\"user\",\"roles\":[],\"password\":\"secret\"}",
     Url = lists:concat([
-        get_base_url(), "/", ?b2l(AuthDb), "/org.couchdb.user:", Name]),
+        get_cluster_base_url(), "/", ?b2l(AuthDb), "/org.couchdb.user:", Name]),
     {ok, 201, _, _} = do_request(put, Url, Body),
     % let's proceed after giving couch_peruser some time to create the user db
     timer:sleep(2000).
 
+create_anon_user(AuthDb, Name) ->
+    Body = "{\"name\":\"" ++ Name ++
+        "\",\"type\":\"user\",\"roles\":[],\"password\":\"secret\"}",
+    Url = lists:concat([
+        get_cluster_base_url(), "/", ?b2l(AuthDb), "/org.couchdb.user:", Name]),
+    {ok, 201, _, _} = do_anon_request(put, Url, Body),
+    % let's proceed after giving couch_peruser some time to create the user db
+    timer:sleep(2000).
+
 delete_user(AuthDb, Name) ->
-    Url = lists:concat([get_base_url(), "/", ?b2l(AuthDb),
+    Url = lists:concat([get_cluster_base_url(), "/", ?b2l(AuthDb),
         "/org.couchdb.user:", Name]),
     {ok, 200, _, Body} = do_request(get, Url),
     {DocProps} = jiffy:decode(Body),
@@ -116,6 +132,11 @@ get_cluster_base_url() ->
 should_create_user_db(TestAuthDb) ->
     create_user(TestAuthDb, "foo"),
     ?_assert(lists:member(<<"userdb-666f6f">>, all_dbs())).
+
+should_create_anon_user_db(TestAuthDb) ->
+    create_anon_user(TestAuthDb, "fooo"),
+    io:fwrite("HELLO: " ++ ?b2l(TestAuthDb) ++ "~n", []),
+    ?_assert(lists:member(<<"userdb-666f6f6f">>, all_dbs())).
 
 should_not_delete_user_db(TestAuthDb) ->
     User = "foo",
@@ -263,6 +284,7 @@ couch_peruser_test_() ->
                 foreach,
                 fun setup/0, fun teardown/1,
                 [
+                    fun should_create_anon_user_db/1,
                     fun should_create_user_db/1,
                     fun should_not_delete_user_db/1,
                     fun should_delete_user_db/1,


### PR DESCRIPTION
I tried to set up CouchDB 2.0 with couchdb_peruser enabled. I saw (in
previous email in the user-archive) that it haven't been tested with 2.0. At the
same time, tests are passing but when using CouchDB normally user creation
does not trigger a database creation.

I investigated the logic behind and the mechanisms is only working when
users are added to the node-only _users database. Users added to the
cluster are not watched for systematic database creation.

The previous set up is relatively strange, as user databases (userdb-xxxx)
are added to the cluster but not to the local node (they are sharded).

Previously, couch_peruser relies on couch_changes:handle_db_changes which is
local-node specific and I do not find an equivalent for the cluster.

I hack together an updated version of couch_peruser that spawn_opt an
couch_changes:handle_db_changes for each local shard of the cluster
authentication_db.

Would that approach be ok ?
It there any point in keeping the previous logic working ? (Local users but
clustered user dbs.)

I am pretty new at CouchDB and at Erlang so pardon my basic understanding
of the different mechanisms.
